### PR TITLE
Print to console using CPX / CRTP

### DIFF
--- a/GAP8/test_functionalities/wifi_jpeg_streamer/com.h
+++ b/GAP8/test_functionalities/wifi_jpeg_streamer/com.h
@@ -1,3 +1,30 @@
+/**
+ * ,---------,       ____  _ __
+ * |  ,-^-,  |      / __ )(_) /_______________ _____  ___
+ * | (  O  ) |     / __  / / __/ ___/ ___/ __ `/_  / / _ \
+ * | / ,--´  |    / /_/ / / /_/ /__/ /  / /_/ / / /_/  __/
+ *    +------`   /_____/_/\__/\___/_/   \__,_/ /___/\___/
+ *
+ * AI-deck GAP8 second stage bootloader
+ *
+ * Copyright (C) 2022 Bitcraze AB
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, in version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ *
+ * com.h - SPI interface for ESP32 communication
+ */
+
 #include <stdint.h>
 
 #ifndef __COM_H__

--- a/GAP8/test_functionalities/wifi_jpeg_streamer/cpx.c
+++ b/GAP8/test_functionalities/wifi_jpeg_streamer/cpx.c
@@ -1,27 +1,72 @@
+/**
+ * ,---------,       ____  _ __
+ * |  ,-^-,  |      / __ )(_) /_______________ _____  ___
+ * | (  O  ) |     / __  / / __/ ___/ ___/ __ `/_  / / _ \
+ * | / ,--´  |    / /_/ / / /_/ /__/ /  / /_/ / / /_/  __/
+ *    +------`   /_____/_/\__/\___/_/   \__,_/ /___/\___/
+ *
+ * AI-deck GAP8 second stage bootloader
+ *
+ * Copyright (C) 2022 Bitcraze AB
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, in version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ *
+ * cpx.c - Interface for CPX stack
+ */
 #pragma once
 
 #include <stdint.h>
 #include "com.h"
-
+#include "pmsis.h"
 #include "cpx.h"
 
-static packet_t txp;
-static packet_t rxp;
+typedef struct
+{
+  uint16_t length; // Length data from cpxDst
+  uint8_t cpxDst : 3;
+  uint8_t cpxSrc : 3;
+  bool lastPacket : 1;
+  bool reserved : 1;
+  uint8_t cpxFunc;
+  uint8_t data[MTU - CPX_HEADER_SIZE];
+} __attribute__((packed)) spi_transport_with_routing_packet_t;
+
+static spi_transport_with_routing_packet_t txp;
+static spi_transport_with_routing_packet_t rxp;
 
 // Return length of packet
 uint32_t cpxReceivePacketBlocking(CPXPacket_t * packet) {
-  uint32_t size;
-  com_read(&rxp);
-  size = rxp.len;
-  memcpy(&packet->routing, rxp.data, size);
+  com_read((packet_t*) &rxp);
+  uint32_t size = rxp.length - sizeof(CPXRouting_t);
+
+  size = (uint32_t) rxp.length - CPX_HEADER_SIZE;
+  packet->route.destination = rxp.cpxDst;
+  packet->route.source = rxp.cpxSrc;
+  packet->route.function = rxp.cpxFunc;
+  memcpy(packet->data, rxp.data, size);
+
   return size;
 }
 
 void cpxSendPacketBlocking(CPXPacket_t * packet, uint32_t size) {
-  uint32_t wireLength = size + sizeof(CPXRouting_t);
-  txp.len = wireLength;
-  memcpy(txp.data, &packet->routing, wireLength);
-  com_write(&txp);
+  txp.length = size + CPX_HEADER_SIZE;
+  txp.cpxDst = packet->route.destination;
+  txp.cpxSrc = packet->route.source;
+  txp.cpxFunc = packet->route.function;
+  memcpy(txp.data, &packet->data, size);
+
+  com_write((packet_t*) &txp);
 }
 
 bool cpxSendPacket(CPXPacket_t * packet, uint32_t timeoutInMS) {

--- a/GAP8/test_functionalities/wifi_jpeg_streamer/cpx.c
+++ b/GAP8/test_functionalities/wifi_jpeg_streamer/cpx.c
@@ -59,6 +59,22 @@ uint32_t cpxReceivePacketBlocking(CPXPacket_t * packet) {
   return size;
 }
 
+static CPXPacket_t consoleTx;
+void cpxPrintToConsole(CPXConsoleTarget_t target, const char * fmt, ...) {
+  va_list ap;
+  int len;
+
+  va_start(ap, fmt);
+  len = vsnprintf(consoleTx.data, sizeof(consoleTx.data), fmt, ap);
+  va_end(ap);
+
+  consoleTx.route.destination = target;
+  consoleTx.route.source = GAP8;
+  consoleTx.route.function = CONSOLE;
+
+  cpxSendPacketBlocking(&consoleTx, len + 1);
+}
+
 void cpxSendPacketBlocking(CPXPacket_t * packet, uint32_t size) {
   txp.length = size + CPX_HEADER_SIZE;
   txp.cpxDst = packet->route.destination;
@@ -67,8 +83,4 @@ void cpxSendPacketBlocking(CPXPacket_t * packet, uint32_t size) {
   memcpy(txp.data, &packet->data, size);
 
   com_write((packet_t*) &txp);
-}
-
-bool cpxSendPacket(CPXPacket_t * packet, uint32_t timeoutInMS) {
-  // TODO
 }

--- a/GAP8/test_functionalities/wifi_jpeg_streamer/cpx.h
+++ b/GAP8/test_functionalities/wifi_jpeg_streamer/cpx.h
@@ -72,4 +72,4 @@ uint32_t cpxReceivePacketBlocking(CPXPacket_t * packet);
 
 void cpxSendPacketBlocking(CPXPacket_t * packet, uint32_t size);
 
-bool cpxSendPacket(CPXPacket_t * packet, uint32_t timeoutInMS);
+void cpxPrintToConsole(CPXConsoleTarget_t target, const char * fmt, ...);

--- a/GAP8/test_functionalities/wifi_jpeg_streamer/cpx.h
+++ b/GAP8/test_functionalities/wifi_jpeg_streamer/cpx.h
@@ -1,3 +1,30 @@
+/**
+ * ,---------,       ____  _ __
+ * |  ,-^-,  |      / __ )(_) /_______________ _____  ___
+ * | (  O  ) |     / __  / / __/ ___/ ___/ __ `/_  / / _ \
+ * | / ,--´  |    / /_/ / / /_/ /__/ /  / /_/ / / /_/  __/
+ *    +------`   /_____/_/\__/\___/_/   \__,_/ /___/\___/
+ *
+ * AI-deck GAP8 second stage bootloader
+ *
+ * Copyright (C) 2022 Bitcraze AB
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, in version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ *
+ * cpx.h - Interface for CPX stack
+ */
+
 #pragma once
 
 #include <stdint.h>
@@ -5,12 +32,14 @@
 
 #include "com.h"
 
+#define CPX_HEADER_SIZE           (2)
+
 typedef enum {
   STM32 = 1,
   ESP32 = 2,
   HOST = 3,
   GAP8 = 4
-} __attribute__((packed)) CPXTarget_t; // Rename to Destination
+} CPXTarget_t; // Rename to Destination
 
 typedef enum {
   SYSTEM = 1,
@@ -20,20 +49,23 @@ typedef enum {
   APP = 5,
   TEST = 0x0E,
   BOOTLOADER = 0x0F,
-} __attribute__((packed)) CPXFunction_t;
+} CPXFunction_t;
+
+typedef enum {
+  LOG_TO_WIFI = HOST,
+  LOG_TO_CRTP = STM32
+} CPXConsoleTarget_t;
 
 typedef struct {
-  uint8_t destination : 3;
-  uint8_t source : 3;
-  bool lastPacket : 1;
-  bool reserved : 1;
-  uint8_t function;
-} __attribute__((packed)) CPXRouting_t;
+  CPXTarget_t destination;
+  CPXTarget_t source;
+  CPXFunction_t function;
+} CPXRouting_t;
 
 typedef struct {
-    CPXRouting_t routing;
+    CPXRouting_t route;
     uint8_t data[MTU-2];
-} __attribute__((packed)) CPXPacket_t;
+} CPXPacket_t;
 
 // Return length of packet
 uint32_t cpxReceivePacketBlocking(CPXPacket_t * packet);

--- a/GAP8/test_functionalities/wifi_jpeg_streamer/test.c
+++ b/GAP8/test_functionalities/wifi_jpeg_streamer/test.c
@@ -65,7 +65,7 @@ void rx_task(void *parameters)
   {
     cpxReceivePacketBlocking(&rxp);
 
-    if (rxp.routing.function == WIFI_CTRL) {
+    if (rxp.route.function == WIFI_CTRL) {
       WiFiCTRLPacket_t * wifiCtrl = (WiFiCTRLPacket_t*) rxp.data;
 
       switch (wifiCtrl->cmd)
@@ -132,9 +132,9 @@ void camera_task(void *parameters)
   static char ssid[] = "WiFi streaming example";
   printf("Setting up WiFi AP\n");
   // Set up the routing for the WiFi CTRL packets
-  txp.routing.destination = ESP32;
-  rxp.routing.source = GAP8;
-  txp.routing.function = WIFI_CTRL;
+  txp.route.destination = ESP32;
+  rxp.route.source = GAP8;
+  txp.route.function = WIFI_CTRL;
 
   WiFiCTRLPacket_t * wifiCtrl = (WiFiCTRLPacket_t*) txp.data;
   
@@ -222,9 +222,9 @@ void camera_task(void *parameters)
         end = xTaskGetTickCount();
         printf("Encoded in %u ms (size is %u)\n", end - start, jpegSize);
 
-        txp.routing.destination = HOST;
-        txp.routing.source = GAP8;
-        txp.routing.function = APP;
+        txp.route.destination = HOST;
+        txp.route.source = GAP8;
+        txp.route.function = APP;
 
         uint32_t imgSize = headerSize + jpegSize + footerSize;
 
@@ -272,9 +272,9 @@ void camera_task(void *parameters)
       {
         start = xTaskGetTickCount();
 
-        txp.routing.destination = HOST;
-        txp.routing.source = GAP8;
-        txp.routing.function = APP;
+        txp.route.destination = HOST;
+        txp.route.source = GAP8;
+        txp.route.function = APP;
 
         // First send information about the image
         img_header_t *header = (img_header_t *)txp.data;


### PR DESCRIPTION
Added printing to console via CPX, either WiFi or CRTP. This will print the current messages over CRTP to the Crazyflie client console.