### PR TITLE
Fixed links for web/repo doc

### DIFF
--- a/docs/getting-started/cpx.md
+++ b/docs/getting-started/cpx.md
@@ -5,7 +5,7 @@ page_id: cpx
 
 The Creazyflie Packet eXchange protocol is used to send data to/from the GAP8 from/to other target systems,
 like the STM32, ESP32 or the host computer. For more information on the inner workings of CPX, have a look
-at the [CPX documentation](/documentation/repository/crazyflie-firmware/master/functional-areas/cpx/).
+at the [CPX documentation](https://www.bitcraze.io/documentation/repository/crazyflie-firmware/master/functional-areas/cpx/).
 
 ## Using CPX
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,7 +8,7 @@ documentation for developing for the GAP8. The examples are a good starting poin
 creating your own applications.
 
 The examples in this repository rely on the fact that the
-[Getting started with the AI deck tutorial](/documentation/tutorials/getting-started-with-aideck/)
+[Getting started with the AI deck tutorial](https://www.bitcraze.io/documentation/tutorials/getting-started-with-aideck/)
 has been completed. This means that all the firmware is up to date,
 the GAP8 bootloader has been flashed and the Crazyflie is used
 to set up the WiFi on the ESP32 in access point mode.

--- a/docs/test-functions/wifi-streamer.md
+++ b/docs/test-functions/wifi-streamer.md
@@ -8,7 +8,7 @@ colorized.
 
 ## Prerequisites
 
-* Completed the [Getting started with the AI deck tutorial](/documentation/tutorials/getting-started-with-aideck/)
+* Completed the [Getting started with the AI deck tutorial](https://www.bitcraze.io/documentation/tutorials/getting-started-with-aideck/)
 * opencv-python installed on host
 
 ## Configuration


### PR DESCRIPTION
Got this error when building the website, the URLs were wrong:

```
 ./_site/documentation/repository/aideck-gap8-examples/master/getting-started/cpx/index.html
Ran on 422 files!
  *  internally linking to /documentation/repository/aideck-gap8-examples/master/documentation/repository/crazyflie-firmware/master/functional-areas/cpx/, which does not exist (line 1215)

     <a href="/documentation/repository/aideck-gap8-examples/master/documentation/repository/crazyflie-firmware/master/functional-areas/cpx/">CPX documentation</a>

- ./_site/documentation/repository/aideck-gap8-examples/master/index.html
  *  internally linking to /documentation/repository/aideck-gap8-examples/master/documentation/tutorials/getting-started-with-aideck/, which does not exist (line 1212)
     <a href="/documentation/repository/aideck-gap8-examples/master/documentation/tutorials/getting-started-with-aideck/">Getting started with the AI deck tutorial</a>
- ./_site/documentation/repository/aideck-gap8-examples/master/test-functions/wifi-streamer/index.html
  *  internally linking to /documentation/repository/aideck-gap8-examples/master/documentation/tutorials/getting-started-with-aideck/, which does not exist (line 1219)
     <a href="/documentation/repository/aideck-gap8-examples/master/documentation/tutorials/getting-started-with-aideck/">Getting started with the AI deck tutorial</a>

HTML-Proofer found 3 failures!
```

This should be fixed now.