### PR TITLE
Adds minimal gap8->CF hello world example for tutorial

### DIFF
--- a/examples/other/hello_world_gap8/Makefile
+++ b/examples/other/hello_world_gap8/Makefile
@@ -1,0 +1,10 @@
+io=uart
+PMSIS_OS = freertos
+
+APP = hello_world_gap8
+APP_SRCS += hello_world_gap8.c ../../../lib/cpx/src/com.c ../../../lib/cpx/src/cpx.c
+APP_INC=../../../lib/cpx/inc
+APP_CFLAGS += -O3 -g
+APP_CFLAGS += -DconfigUSE_TIMERS=1 -DINCLUDE_xTimerPendFunctionCall=1
+
+include $(RULES_DIR)/pmsis_rules.mk

--- a/examples/other/hello_world_gap8/hello_world_gap8.c
+++ b/examples/other/hello_world_gap8/hello_world_gap8.c
@@ -1,0 +1,44 @@
+/**
+ * ,---------,       ____  _ __
+ * |  ,-^-,  |      / __ )(_) /_______________ _____  ___
+ * | (  O  ) |     / __  / / __/ ___/ ___/ __ `/_  / / _ \
+ * | / ,--´  |    / /_/ / / /_/ /__/ /  / /_/ / / /_/  __/
+ *    +------`   /_____/_/\__/\___/_/   \__,_/ /___/\___/
+ *
+ * AI-deck GAP8
+ *
+ * Copyright (C) 2022 Bitcraze AB
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, in version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Hello world example
+ */
+#include "pmsis.h"
+#include "bsp/bsp.h"
+#include "cpx.h"
+
+void start_example(void)
+{
+  pi_bsp_init();
+  cpxInit();
+   while (1)
+  {
+      cpxPrintToConsole(LOG_TO_CRTP, "Hello World\n");
+      pi_time_wait_us(1000*1000);
+  }
+}
+
+int main(void)
+{
+  return pmsis_kickoff((void *)start_example);
+}


### PR DESCRIPTION
This adds a minimal example to print "Hello World" in the cfclient console from gap8. It is used for a WIP tutorial which will be pushed to the website.
This is a start to address issue #116 .