### PR TITLE
AI deck documentation changes  

### DIFF
--- a/docs/_data/menu.yml
+++ b/docs/_data/menu.yml
@@ -4,9 +4,7 @@
       - {page_id: gap8}
       - {page_id: flashing}
       - {page_id: cpx}
-- title: Guides
-  subs:
-      - {page_id: replace-ai-deck-camera}
+      - {page_id: helloworld}
 - title: Image Processing examples
   subs:
       - {page_id: face-detection}
@@ -18,3 +16,6 @@
       - {page_id: test-camera}
       - {page_id: uart-send-char}
       - {page_id: wifi-streamer}
+- title: Guides
+  subs:
+      - {page_id: replace-ai-deck-camera}

--- a/docs/_data/menu.yml
+++ b/docs/_data/menu.yml
@@ -4,7 +4,10 @@
       - {page_id: gap8}
       - {page_id: flashing}
       - {page_id: cpx}
+- title: Simple Examples
+  subs:
       - {page_id: helloworld}
+      - {page_id: wifi-streamer}
 - title: Image Processing examples
   subs:
       - {page_id: face-detection}
@@ -15,7 +18,6 @@
   subs:
       - {page_id: test-camera}
       - {page_id: uart-send-char}
-      - {page_id: wifi-streamer}
 - title: Guides
   subs:
       - {page_id: replace-ai-deck-camera}

--- a/docs/getting-started/hello-world.md
+++ b/docs/getting-started/hello-world.md
@@ -1,0 +1,28 @@
+---
+title: Hello World Example
+page_id: helloworld
+---
+
+This simple example will show how to make an app for the GAP88 chip, which sends a string that is printed out on the console on the [CFclient](https://www.bitcraze.io/documentation/repository/crazyflie-clients-python/master/) through the [CPX framework](/docs/getting_started/cpx.md).
+
+> Make sure you have completed the [Getting started with the AI deck tutorial](https://www.bitcraze.io/documentation/tutorials/getting-started-with-aideck/) first
+
+First build the hello world example:
+
+```
+$ docker run --rm -v ${PWD}:/module aideck-with-autotiler tools/build/make-example examples/other/hello_world_gap8 image
+```
+
+Then flash the example on the AIdeck
+
+```
+$ python -m cfloader flash examples/other/hello_world_gap8/BUILD/GAP8_V2/GCC_RISCV_FREERTOS/target.board.devices.flash.img deck-bcAI:gap8-fw -w radio://0/80/2M
+```
+> Note: Replace the 'radio://0/80/2M' with your crazyflie's URI
+
+Connect to the Crazyflie with the CFclient and open up the console tab. You should see the following output:
+```
+CPX: GAP8: Hello world
+CPX: GAP8: Hello world
+```
+

--- a/docs/img-proc-examples/face-detection.md
+++ b/docs/img-proc-examples/face-detection.md
@@ -3,21 +3,28 @@ title: Face detection example
 page_id: face-detection
 ---
 
-This is the face detection application based on the example as developed by Greenwaves technologies. It is a bit more tailor made towards the AI-deck and uses the wifi streamer to stream the output to your computer. 
+This is the face detection application based on the example as developed by Greenwaves technologies. It is a bit more tailor made towards the AI-deck and uses the wifi streamer to stream the output to your computer.
 
 This was tested on **GAP_SDK version 4.8.0.2**, which at the moment of writing was the newest we had a docker container for.
 
-# Docker GAP-SDK 
+# Docker GAP-SDK
 
 Make sure to follow the [getting started with the AI deck tutorial](https://www.bitcraze.io/documentation/tutorials/getting-started-with-aideck/) before continuing.
 
-To clean, compile and flash the FaceDetection example you have to be in the aideck-gap8-examples directory and execute: 
+To clean, compile and flash the FaceDetection example you have to be in the aideck-gap8-examples directory and execute:
 
-    docker run --rm -v ${PWD}:/module --privileged aideck-with-autotiler tools/build/make-example examples/image_processing/FaceDetection clean all flash
+```
+$ docker run --rm -v ${PWD}:/module aideck-with-autotiler tools/build/make-example examples/image_processing/FaceDetection clean model build image
+```
+Then flash the example with cfloader:
+```
+$ cfloader flash examples/image_processing/FaceDetection/BUILD/GAP8_V2/GCC_RISCV_FREERTOS/target.board.devices.flash.img deck-bcAI:gap8-fw -w [CRAZYFLIE URI]
+```
 
-(if you did not modify the Makefile it should be possible to skip the _clean_).
+> Replace `[CRAZYFLIE_URI]` with the URI of your crazyflie in the form radio://0/2M/80/E7E7E7E7E7
 
-If you configured your Crazyflie firmware such that the AIdeck will act as access point (as described in the [wifi-streamer example](/docs/test-functions/wifi-streamer.md)) you can now just connect to it. If you configured it to connect to an existing network you should make sure your computer is in the same network and you need to check the IP address of the AIdeck - for example connect to it through the cfclient and check the console prints. 
+
+If you configured your Crazyflie firmware such that the AIdeck will act as access point (as described in the [wifi-streamer example](/docs/test-functions/wifi-streamer.md)) you can now just connect to it. If you configured it to connect to an existing network you should make sure your computer is in the same network and you need to check the IP address of the AIdeck - for example connect to it through the cfclient and check the console prints.
 
 Now you can run the image viewer:
 
@@ -29,35 +36,11 @@ Now you should see something like this:
 
 ![image streamer](/docs/images/face_detection.png)
 
-Note that the face detection does not work great under all conditions - try with a white background and dark hair... 
+Note that the face detection does not work great under all conditions - try with a white background and dark hair...
 
 In the makefile you can comment the following line if you would like to disable the streamer:
 
-    APP_CFLAGS += -DUSE_STREAMER 
+    APP_CFLAGS += -DUSE_STREAMER
 
 Or - what is way more fun to play with - you can set the resolution of the streamed image with _STREAM\_W_ and _STREAM\_H_. Note that you cannot set values higher than 324x244 and that unproportional changes will result in distorted images. Note also that you need to adapt the resolution in the _opencv-viewer.py_ as well.
 
-# Local GAP-SDK installation
-
-> Working directory: aideck-gap8-examples/examples/image_processing/FaceDetection
-
-To make the face detection application
-
-    make clean
-    make all PMSIS_OS=pulpos
-
-To try out the code on RAM with help of the debugger:
-
-    make run
-
-To flash the code fully on the ai deck:
-
-    make image
-    make flash
-    
-
-In the makefile you can comment the following line if you would like to disable the streamer:
-
-    APP_CFLAGS += -DUSE_STREAMER 
-
-After that, you can also use `opencv-viewer.py` to see the image stream. The rectangle generated around your face is implemented by the firmware.

--- a/docs/img-proc-examples/face-detection.md
+++ b/docs/img-proc-examples/face-detection.md
@@ -7,7 +7,7 @@ This is the face detection application based on the example as developed by Gree
 
 This was tested on **GAP_SDK version 4.8.0.2**, which at the moment of writing was the newest we had a docker container for.
 
-# Docker GAP-SDK
+## Building with Docker GAP-SDK
 
 Make sure to follow the [getting started with the AI deck tutorial](https://www.bitcraze.io/documentation/tutorials/getting-started-with-aideck/) before continuing.
 


### PR DESCRIPTION
This PR does a couple of things:
- Adds a hello-world doc based on the new example in #118
- Changes doc on the face detection example to separate docker building and cfloader flashing
- Changes to the menu structure

For the latter, we should standardize the doc to follow the folder structure, since the menu structure has changed already before compared to the doc structure. I've made an issue ( #119) for this so that we can fix that in a next PR.