### PR TITLE
[CPX] custom data types from gap8 to stm32

### DIFF
--- a/examples/other/send_data/Makefile
+++ b/examples/other/send_data/Makefile
@@ -1,0 +1,10 @@
+io=uart
+PMSIS_OS = freertos
+
+APP = send_data
+APP_SRCS += send_data.c ../../../lib/cpx/src/com.c ../../../lib/cpx/src/cpx.c
+APP_CFLAGS += -O3 -g
+APP_INC=../../../lib/cpx/inc
+APP_CFLAGS += -DconfigUSE_TIMERS=1 -DINCLUDE_xTimerPendFunctionCall=1
+
+include $(RULES_DIR)/pmsis_rules.mk

--- a/examples/other/send_data/msg.h
+++ b/examples/other/send_data/msg.h
@@ -1,0 +1,130 @@
+#ifndef MSG_H
+#define MSG_H
+
+#define MSG_SIZE 53
+#define GAP8_ENABLED true
+
+#include "stdio.h"
+
+#if GAP8_ENABLED
+  #include "pmsis.h"
+#endif
+
+typedef struct _Pixel
+{
+  uint16_t x; // uint16 (2 bytes)
+  uint16_t y; // uint16 (2 bytes)
+} __attribute__((packed)) Pixel;
+
+typedef struct _TagPacket
+{
+  uint8_t id; // uint8 (1 byte) = 1
+  Pixel corners[4]; // Pixel (4 bytes) * 4 = 16
+  float homography[3][3]; // float (4 bytes) * 3 * 3 = 36
+} __attribute__((packed)) TagPacket;
+
+#if GAP8_ENABLED
+  // https://stackoverflow.com/a/6002598
+  static void reserve_space(uint8_t *data, size_t bytes,
+    uint8_t *size, uint8_t *next) 
+  {
+    if((*next + bytes) > *size) {
+      // double size to enforce O(lg N) reallocs
+      // data = realloc(data, *size * 2);
+      // *size *= 2;
+    }
+  }
+  
+  static void serialize_uint8(uint8_t x, uint8_t *data, 
+    uint8_t *size, uint8_t *next) 
+  {
+    reserve_space(data, sizeof(uint8_t), size, next);
+
+    memcpy(data + *next, &x, sizeof(uint8_t));
+    *next += sizeof(uint8_t);
+  }
+
+  static void serialize_uint16(uint16_t x, uint8_t *data, 
+    uint8_t *size, uint8_t *next) 
+  {
+    reserve_space(data, sizeof(uint16_t), size, next);
+
+    memcpy(data + *next, &x, sizeof(uint16_t));
+    *next += sizeof(uint16_t);
+  }
+
+  static void serialize_float(float x, uint8_t *data, 
+    uint8_t *size, uint8_t *next) 
+  {
+    reserve_space(data, sizeof(float), size, next);
+
+    memcpy(data + *next, &x, sizeof(float));
+    *next += sizeof(float);
+  }
+
+  static void serialization(TagPacket tp, CPXPacket_t *pkt) 
+  { 
+    uint8_t size = MSG_SIZE;
+    uint8_t next = 0;
+
+    pkt->dataLength = (uint16_t)size;
+
+    serialize_uint8(tp.id, pkt->data, &size, &next);
+    for (size_t i = 0; i < sizeof(tp.corners)/sizeof(Pixel); ++i)
+    {
+      serialize_uint16(tp.corners[i].x, pkt->data, &size, &next);
+      serialize_uint16(tp.corners[i].y, pkt->data, &size, &next);
+    }
+    for (int i = 0; i < 3; ++i)
+      for (int j = 0; j < 3; ++j)
+          serialize_float(tp.homography[i][j], pkt->data, &size, &next);
+  }
+#endif
+
+static void deserialize_uint8(uint8_t *x, uint8_t *data, 
+  uint8_t *next) 
+{
+  memcpy(x, data + *next, sizeof(uint8_t));
+  *next += sizeof(uint8_t);
+}
+
+static void deserialize_uint16(uint16_t *x, uint8_t *data, 
+  uint8_t *next) 
+{
+  memcpy(x, data + *next, sizeof(uint16_t));
+  *next += sizeof(uint16_t);
+}
+
+static void deserialize_float(float *x, uint8_t *data, 
+  uint8_t *next) 
+{
+
+  memcpy(x, data + *next, sizeof(float));
+  *next += sizeof(float);
+}
+
+static void deserialization(TagPacket *tp, CPXPacket_t pkt) 
+{
+  uint8_t next = 0;
+
+  deserialize_uint8(&(tp->id), pkt.data, &next);
+  for (size_t i = 0; i < sizeof(tp->corners)/sizeof(Pixel); ++i)
+  {
+    uint16_t x = 0, y = 0;
+    deserialize_uint16(&x, pkt.data, &next);
+    deserialize_uint16(&y, pkt.data, &next);
+    tp->corners[i].x = x;
+    tp->corners[i].y = y;
+  }
+  for (int i = 0; i < 3; ++i)
+  {
+    for (int j = 0; j < 3; ++j)
+    {
+      float x = 0.0f;
+      deserialize_float(&x, pkt.data, &next);
+      tp->homography[i][j] = x;
+    }
+  }
+}
+
+#endif

--- a/examples/other/send_data/send_data.c
+++ b/examples/other/send_data/send_data.c
@@ -1,0 +1,149 @@
+#include "pmsis.h"
+#include "stdio.h"
+#include "bsp/bsp.h"
+
+#include "cpx.h"
+#include "msg.h"
+
+// using a scenario of an april tag detection
+
+static void send_task(void *parameters) {
+
+  uint32_t time_start = pi_time_get_us();
+
+  while (1)
+  {    
+    static CPXPacket_t txp;
+    
+    // send every second
+    if (pi_time_get_us() - time_start > 1000000)
+    {
+      // cpx function
+      txp.route.destination = CPX_T_STM32;
+      // txp.route.source = CPX_T_GAP8;
+      txp.route.function = CPX_F_APP;
+
+      TagPacket tag_packet = {};
+      // tag_packet.id = pi_time_get_us() % 0xFF;
+      tag_packet.id = 1;
+
+      for (int i = 0; i < 4; ++i)
+      {
+        // create a pixel value
+        // tag_packet.corners[i].x = (2 * pi_time_get_us()) % 0xFFFF;
+        // tag_packet.corners[i].y = pi_time_get_us() % 0xFFFF;
+        tag_packet.corners[i].x = i*2;
+        tag_packet.corners[i].y = i*2 + 1;
+      }
+
+      // create a homography element
+      for (int i = 0; i < 3; ++i)
+        for (int j = 0; j < 3; ++j)
+        {
+          // tag_packet.homography[i][j] = (float)(pi_time_get_us() / 1000000);
+          tag_packet.homography[i][j] = (float)(3*i + j);
+        }
+      
+      // debug message variables
+      cpxPrintToConsole(LOG_TO_CRTP, 
+        "(transmit) id(uint8_t) %d c[0](uint16_t) %d, %d h[0][0](float) %f  h[2][2](float) %f\n", 
+        tag_packet.id, tag_packet.corners[0].x, tag_packet.corners[0].y,
+        tag_packet.homography[0][0], tag_packet.homography[2][2]);
+      
+      serialization(tag_packet, &txp);
+
+      // debug message serialized
+      // cpxPrintToConsole(LOG_TO_CRTP, 
+      //   "id(bytes) %x c[0](bytes) %x %x, %x %x h[0][0](bytes) %x %x %x %x\n", 
+      //   txp.data[0], txp.data[1], txp.data[2], txp.data[3],
+      //   txp.data[4], txp.data[17], txp.data[18], txp.data[19],
+      //   txp.data[20]);
+      // cpxPrintToConsole(LOG_TO_CRTP, 
+      //   "(transmit) h[0][0](bytes) %x %x %x %x h[0][1](bytes) %x %x %x %x h[0][2](bytes) %x %x %x %x\n", 
+      //   txp.data[17], txp.data[18], txp.data[19], txp.data[20],
+      //   txp.data[21], txp.data[22], txp.data[23], txp.data[24],
+      //   txp.data[25], txp.data[26], txp.data[27], txp.data[28]);
+
+      vTaskDelay(10);
+
+      cpxSendPacketBlocking(&txp);
+
+      time_start = pi_time_get_us();
+    }
+  }
+}
+
+#define LED_PIN 2
+static pi_device_t led_gpio_dev;
+
+void hb_task(void *parameters)
+{
+  (void)parameters;
+  char *taskname = pcTaskGetName(NULL);
+
+  // Initialize the LED pin
+  pi_gpio_pin_configure(&led_gpio_dev, LED_PIN, PI_GPIO_OUTPUT);
+
+  const TickType_t xDelay = 100 / portTICK_PERIOD_MS;
+
+  while (1)
+  {
+    pi_gpio_pin_write(&led_gpio_dev, LED_PIN, 1);
+    vTaskDelay(xDelay);
+    pi_gpio_pin_write(&led_gpio_dev, LED_PIN, 0);
+    vTaskDelay(xDelay);
+  }
+}
+
+void start_example(void)
+{
+  struct pi_uart_conf conf;
+  struct pi_device device;
+  pi_uart_conf_init(&conf);
+  conf.baudrate_bps = 115200;
+
+  pi_open_from_conf(&device, &conf);
+  if (pi_uart_open(&device))
+  {
+    printf("[UART] open failed !\n");
+    pmsis_exit(-1);
+  }
+
+  printf("\n-- GAP8 send data application --\n");
+
+  BaseType_t xTask;
+
+  xTask = xTaskCreate(hb_task, "hb_task", configMINIMAL_STACK_SIZE * 2,
+                      NULL, tskIDLE_PRIORITY + 1, NULL);
+  if (xTask != pdPASS)
+  {
+    printf("HB task did not start !\n");
+    pmsis_exit(-1);
+  }
+
+  cpxInit();
+
+  xTask = xTaskCreate(send_task, "test_task", configMINIMAL_STACK_SIZE * 2,
+                      NULL, tskIDLE_PRIORITY + 1, NULL);
+  if (xTask != pdPASS)
+  {
+    printf("send task did not start!\n");
+    pmsis_exit(-1);
+  }
+
+  while (1)
+  {
+    pi_yield();
+  }
+}
+
+int main(void)
+{
+  pi_bsp_init();
+
+  // Increase the FC freq to 250 MHz
+  pi_freq_set(PI_FREQ_DOMAIN_FC, 250000000);
+  pi_pmu_voltage_set(PI_PMU_DOMAIN_FC, 1200);
+
+  return pmsis_kickoff((void *)start_example);
+}


### PR DESCRIPTION
This PR addresses https://github.com/bitcraze/aideck-gap8-examples/issues/116
A look at it is as shown below, using an example of sending `apriltag detection of corners` and `pose estimation` related data
![cpx](https://user-images.githubusercontent.com/64059887/222920924-6ef7304a-825d-421c-85cb-77082a3d80b3.png)

`crazyflie-firmware` will need some tweaks, please use https://github.com/matthewoots/crazyflie-firmware/tree/cpx/receive_data and the commit is https://github.com/matthewoots/crazyflie-firmware/commit/9fcb11774fb4d228ea4f339741fb53563b4d7ff3

Adding @hmllr here too