### PR TITLE
CPX communication example

### DIFF
--- a/docs/other-examples/stm_gap8_cpx.md
+++ b/docs/other-examples/stm_gap8_cpx.md
@@ -1,0 +1,46 @@
+---
+title: STM-GAP8 CPX communication Example
+page_id: stm-gap8-cpx
+---
+
+This simple example will show how to make an app for the GAP88 chip, which communicates with the STM (main CPU) on the
+Crazyflie using CPX.
+CPX packets are sent from the STM to the GAP8, containing a counter that is increased for each packet. The same number is
+sent back to the STM in a new CPX packet.
+
+This example is intended to be used together with the STM example "app_stm_gap8_cpx" in the examples folder of the
+[crazyflie-firmware repository](https://github.com/bitcraze/crazyflie-firmware)
+
+
+> Make sure you have completed the [Getting started with the AI deck tutorial](https://www.bitcraze.io/documentation/tutorials/getting-started-with-aideck/) first
+
+First build the stm-gap8-cpx example:
+
+```
+$ docker run --rm -v ${PWD}:/module bitcraze/aideck tools/build/make-example examples/other/stm_gap8_cpx all
+```
+
+Then flash the example on the AIdeck
+
+```
+$ python -m cfloader flash examples/other/stm_gap8_cpx/BUILD/GAP8_V2/GCC_RISCV_FREERTOS/target.board.devices.flash.img deck-bcAI:gap8-fw -w radio://0/80/2M
+```
+> Note: Replace the 'radio://0/80/2M' with your crazyflie's URI
+
+Build and flash the app-stm-gap8-cpx in the Crazyflie, see the instruction in the crazyflie-firmware repository.
+
+Connect to the Crazyflie with the CFclient and open up the console tab. You should see the following output:
+```
+APP: Hello! I am the stm_gap8_cpx app
+...
+CPX: GAP8: Starting counter bouncer
+...
+APP: Sent packet to GAP8 (0)
+APP: Got packet from GAP8 (0)
+APP: Sent packet to GAP8 (1)
+APP: Got packet from GAP8 (1)
+APP: Sent packet to GAP8 (2)
+APP: Got packet from GAP8 (2)
+APP: Sent packet to GAP8 (3)
+APP: Got packet from GAP8 (3)
+```

--- a/examples/other/stm_gap8_cpx/Makefile
+++ b/examples/other/stm_gap8_cpx/Makefile
@@ -1,0 +1,10 @@
+io=uart
+PMSIS_OS = freertos
+
+APP = stm_gap8_cpx
+APP_SRCS += stm_gap8_cpx.c ../../../lib/cpx/src/com.c ../../../lib/cpx/src/cpx.c
+APP_INC=../../../lib/cpx/inc
+APP_CFLAGS += -O3 -g
+APP_CFLAGS += -DconfigUSE_TIMERS=1 -DINCLUDE_xTimerPendFunctionCall=1
+
+include $(RULES_DIR)/pmsis_rules.mk

--- a/examples/other/stm_gap8_cpx/stm_gap8_cpx.c
+++ b/examples/other/stm_gap8_cpx/stm_gap8_cpx.c
@@ -1,0 +1,57 @@
+/**
+ * ,---------,       ____  _ __
+ * |  ,-^-,  |      / __ )(_) /_______________ _____  ___
+ * | (  O  ) |     / __  / / __/ ___/ ___/ __ `/_  / / _ \
+ * | / ,--´  |    / /_/ / / /_/ /__/ /  / /_/ / / /_/  __/
+ *    +------`   /_____/_/\__/\___/_/   \__,_/ /___/\___/
+ *
+ * AI-deck GAP8
+ *
+ * Copyright (C) 2023 Bitcraze AB
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, in version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Simple CPX communication with the Crazyflie, use together with the Crazyflie example app "app_stm_gap_cpx"
+ */
+#include "pmsis.h"
+#include "bsp/bsp.h"
+#include "cpx.h"
+
+static CPXPacket_t rxPacket;
+static CPXPacket_t txPacket;
+
+void start_example(void) {
+  pi_bsp_init();
+  cpxInit();
+  cpxEnableFunction(CPX_F_APP);
+
+  cpxPrintToConsole(LOG_TO_CRTP, "Starting counter bouncer\n");
+
+  while (1) {
+    cpxReceivePacketBlocking(CPX_F_APP, &rxPacket);
+    uint8_t counterInStm = rxPacket.data[0];
+
+    // cpxPrintToConsole(LOG_TO_CRTP, "Got packet from the STM (%u)\n", counterInStm);
+
+    // Bounce the same value back to the STM
+    cpxInitRoute(CPX_T_GAP8, CPX_T_STM32, CPX_F_APP, &txPacket.route);
+    txPacket.data[0] = counterInStm;
+    txPacket.dataLength = 1;
+
+    cpxSendPacketBlocking(&txPacket);
+  }
+}
+
+int main(void) {
+  return pmsis_kickoff((void *)start_example);
+}

--- a/examples/other/stm_gap8_cpx/stm_gap8_cpx.c
+++ b/examples/other/stm_gap8_cpx/stm_gap8_cpx.c
@@ -23,6 +23,7 @@
  *
  * Simple CPX communication with the Crazyflie, use together with the Crazyflie example app "app_stm_gap_cpx"
  */
+
 #include "pmsis.h"
 #include "bsp/bsp.h"
 #include "cpx.h"


### PR DESCRIPTION
This PR adds an example that communicates with the STM on the Crazyflie through CPX. The intention is to show how this can be done to facilitate use cases where the Crazyfly for instance is controlled from a neural network running in the GAP8.

This app is intended to be used together with a similar example app in the STM, available in the bitcraze/crazyflie-firmware repository.

Related to PR https://github.com/bitcraze/crazyflie-firmware/pull/1311